### PR TITLE
Change libmm to follow worst-fit approach

### DIFF
--- a/lib/mm/mm.c
+++ b/lib/mm/mm.c
@@ -140,7 +140,7 @@ errval_t mm_alloc_aligned(struct mm *mm, size_t size, size_t alignment, struct c
         return MM_ERR_INVALID_SIZE;
 
     struct mmnode *best = NULL;
-    size_t best_size = SIZE_MAX;
+    size_t best_size = 0;
     size_t best_padding_size = 0;
 
     // Find the smallest node that is still free and can hold the requested size.
@@ -155,8 +155,8 @@ errval_t mm_alloc_aligned(struct mm *mm, size_t size, size_t alignment, struct c
         if (next->size < size + padding_size)
             continue;
 
-        // We want the smallest node possible.
-        if (next->size <= best_size) {
+        // We want the largest node possible to minimize fragmentation (worst-fit).
+        if (next->size >= best_size) {
             best = next;
             best_size = next->size;
             best_padding_size = padding_size;


### PR DESCRIPTION
Using the best-fit approach will cause small leftovers to reside between
allocations. Hence, the fragmentation is actually worse than in a
worst-fit approach.