### PR TITLE
Check alignment for validity in libmm

### DIFF
--- a/errors/errno.fugu
+++ b/errors/errno.fugu
@@ -729,6 +729,7 @@ errors libmm MM_ERR_ {
     failure RESIZE_NODE         "Nested failure in resize_node()",
     failure REALLOC_RANGE       "Nested failure in realloc_range()",
     failure INVALID_SIZE        "The size given is invalid",
+    failure INVALID_ALIGNMENT   "The alignment given is invalid",
 };
 
 // errors in init

--- a/lib/mm/mm.c
+++ b/lib/mm/mm.c
@@ -139,6 +139,9 @@ errval_t mm_alloc_aligned(struct mm *mm, size_t size, size_t alignment, struct c
     if (size == 0)
         return MM_ERR_INVALID_SIZE;
 
+    if (alignment == 0 || alignment % BASE_PAGE_SIZE != 0)
+        return MM_ERR_INVALID_ALIGNMENT;
+
     struct mmnode *best = NULL;
     size_t best_size = SIZE_MAX;
     size_t best_padding_size = 0;


### PR DESCRIPTION
We cannot have an alignment of zero, as that would cause following
calculations to fail. Also, we want the alignment to be a multiple of
BASBASE_PAGE_SIZE, so that fragmentation is minimized.

Fixes #3 and #6.