### PR TITLE
Clarify why args_page is written to enabled_area

### DIFF
--- a/lib/spawn/spawn.c
+++ b/lib/spawn/spawn.c
@@ -461,12 +461,12 @@ static inline errval_t setup_dispatcher(struct paging_state *ps, char *name, str
     disp_child->udisp = (lvaddr_t) dp_page_child;
     disp_child->disabled = 1;
     strncpy(disp_child->name, name, DISP_NAME_LEN);
+
     registers_set_entry(disabled_area, entry_point_addr);
 
-    // The args are currently read from the enabled area. I believe this is a
-    // bug, so we write the arguments page in both areas for now.
+    // The disabled_area is overwritten when the dispatcher is preemted. Hence,
+    // we have to write to the enabled_area.
     registers_set_param(enabled_area, (uint64_t) args_page_child);
-    registers_set_param(disabled_area, (uint64_t) args_page_child);
 
     armv8_set_registers(got_section_addr, handle_child, enabled_area, disabled_area);
     disp_gen->eh_frame = 0;


### PR DESCRIPTION
I've tested this patch on a microcontroller, and the spawning still works.