### PR TITLE
Minor adjustments to the generic LMP server

### DIFF
--- a/include/rpc/server/lmp.h
+++ b/include/rpc/server/lmp.h
@@ -11,9 +11,6 @@ struct rpc_lmp_server {
     struct capref open_ep;
     struct lmp_chan open_lc;
 
-    struct capref service_ep;
-    struct lmp_endpoint *service_lmp_ep;
-
     service_recv_handler_t service_recv_handler;
     state_init_handler_t state_init_handler;
     state_free_handler_t state_free_handler;

--- a/usr/init/main.c
+++ b/usr/init/main.c
@@ -152,6 +152,16 @@ static int bsp_main(int argc, char *argv[])
         abort();
     }
 
+    char *binary_name2 = "hello";
+    struct spawninfo si2;
+    domainid_t pid2;
+
+    err = spawn_load_by_name(binary_name2, &si2, &pid2);
+    if (err_is_fail(err)) {
+        DEBUG_ERR(err, "in event_dispatch");
+        abort();
+    }
+
     // Grading
     grading_test_late();
 


### PR DESCRIPTION
We need different callbacks for all clients, so we can differentiate them in the callback.