### PR TITLE
allocate proper size of new message to prevent heap data overwrite

### DIFF
--- a/lib/rpc/rpc_lmp_server.c
+++ b/lib/rpc/rpc_lmp_server.c
@@ -60,7 +60,7 @@ static void service_recv_cb(void *arg)
         }
 
         // Allocate memory for the full message
-        state->msg = (struct rpc_message *) calloc(1, bytes_total);
+        state->msg = (struct rpc_message *) calloc(1, sizeof(struct rpc_message) + header->payload_length);
         if (state->msg == NULL) {
             debug_printf("calloc() failed\n");
             goto reset_state;


### PR DESCRIPTION
fixes #75 
heap overflow due to wrong message size. allocated was only `full_msg_size(*header)` which did not include a capref as defined in `(struct rpc_message)` Succeeding mallocs caused data overwrite